### PR TITLE
disable implicit-function-declaration for FreeBSD

### DIFF
--- a/v.c
+++ b/v.c
@@ -5860,7 +5860,7 @@ void V_cc(V *v) {
     _PUSH(&a, (tos2((byte *)"-g")), tmp6, string);
   };
 
-  if (v->os != main__OS_msvc) {
+  if (v->os != main__OS_msvc && v->os != main__OS_freebsd) {
 
     _PUSH(&a, (tos2((byte *)"-Werror=implicit-function-declaration")), tmp7,
           string);


### PR DESCRIPTION
To compile V on FreeBSD, "-Werror=implicit-function-declaration" in both v.c and cc.v must be disabled or there will be errors